### PR TITLE
Fix ‹Antique› preview

### DIFF
--- a/site/src/_styles.css
+++ b/site/src/_styles.css
@@ -758,7 +758,7 @@ h2#characters {
 }
 
 .antique {
-  font-family: Superclarendon, 'Bookman Old Style', 'Sitka Heading', 'URW Bookman', 'URW Bookman L', 'Georgia Pro', Georgia, serif;
+  font-family: Superclarendon, 'Bookman Old Style', 'URW Bookman', 'URW Bookman L', 'Georgia Pro', Georgia, serif;
 }
 
 .didone {


### PR DESCRIPTION
The preview site defines extra `'Sitka Heading'` in the `.antique` class, not matching how the font stack is defined otherwise.

This removes it from the preview CSS to match its specified stack.

Resolves #40